### PR TITLE
refact: factor out base spaceship rent logic to space factory

### DIFF
--- a/contracts/BaseSpaceshipNFT.sol
+++ b/contracts/BaseSpaceshipNFT.sol
@@ -3,151 +3,100 @@ pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Consecutive.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
 import "./interfaces/IBaseSpaceshipNFT.sol";
 
 // Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
 // @TODO add natspec comments
-contract BaseSpaceshipNFT is
-    ERC721Consecutive,
-    AccessControl,
-    IBaseSpaceshipNFT
-{
+contract BaseSpaceshipNFT is ERC721Consecutive, IBaseSpaceshipNFT {
     /* ============ Variables ============ */
 
-    bytes32 public constant SPACE_FACTORY = keccak256("SPACE_FACTORY");
-    uint16 public constant MAXIMUM = 1000;
-    uint32 public constant ACCESS_PERIOD = 7 days;
+    uint public totalSupply;
+    uint16 public constant MAXIMUM_SUPPLY = 1000;
 
-    mapping(address => Access) private _accesses;
-    mapping(uint256 => address) private _userAddresses;
+    mapping(uint256 => UserInfo) private _users;
 
     /* ============ Structs ============ */
 
-    struct Access {
-        uint256 tokenId;
-        address user;
-        uint64 expirationDate;
-    }
-
-    /* ============ Events ============ */
-
-    event GrantAccess(address indexed user, uint256 indexed tokenId);
-    event ExtendAccess(
-        address indexed user,
-        uint256 indexed tokenId,
-        uint64 expirationDate
-    );
-
-    /* ============ Errors ============ */
-
-    error AlreadyHaveAccess(address user, uint256 tokenId);
-    error AlreadyClaimedToken(uint256 tokenId);
-    error NotWithinExtensionPeriod(address user, uint256 tokenId);
-
-    /* ============ Modifiers ============ */
-
-    modifier onlyUserWithoutAccess(address user, uint256 tokenId) {
-        if (
-            _accesses[user].user == user &&
-            _accesses[user].expirationDate - ACCESS_PERIOD > block.timestamp
-        ) {
-            revert AlreadyHaveAccess(user, tokenId);
-        }
-        _;
-    }
-
-    modifier onlyTokenWithoutAccess(uint256 tokenId) {
-        if (
-            _accesses[_userAddresses[tokenId]].expirationDate - ACCESS_PERIOD >
-            block.timestamp
-        ) {
-            revert AlreadyClaimedToken(tokenId);
-        }
-        _;
-    }
-
-    modifier onlyTokenWithinExtensionPeriod(address user, uint256 tokenId) {
-        if (
-            _accesses[user].user == user ||
-            _accesses[_userAddresses[tokenId]].expirationDate <
-            block.timestamp ||
-            _accesses[_userAddresses[tokenId]].expirationDate >
-            block.timestamp + ACCESS_PERIOD
-        ) {
-            revert NotWithinExtensionPeriod(user, tokenId);
-        }
-        _;
+    struct UserInfo {
+        address user; // address of user role
+        uint64 expires; // unix timestamp, user expires
     }
 
     /* ============ Constructor ============ */
 
     constructor(address spaceFactory) ERC721("Base Spaceship", "BASE") {
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(SPACE_FACTORY, spaceFactory);
-        _mintConsecutive(msg.sender, MAXIMUM);
+        _mintConsecutive(spaceFactory, MAXIMUM_SUPPLY);
+        totalSupply = MAXIMUM_SUPPLY;
     }
 
     /* ============ External Functions ============ */
 
-    // @TODO add parameter checks
-    function grantAccess(
+    /// @notice set the user and expires of an NFT
+    /// @dev The zero address indicates there is no user
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(
+        uint256 tokenId,
         address user,
-        uint256 tokenId
-    )
-        external
-        onlyRole(SPACE_FACTORY)
-        onlyUserWithoutAccess(user, tokenId)
-        onlyTokenWithoutAccess(tokenId)
-    {
-        _accesses[user] = Access(
-            tokenId,
-            user,
-            uint64(block.timestamp + ACCESS_PERIOD)
+        uint64 expires
+    ) public virtual {
+        require(
+            _isApprovedOrOwner(msg.sender, tokenId),
+            "ERC4907: transfer caller is not owner nor approved"
         );
-        _userAddresses[tokenId] = user;
-        emit GrantAccess(user, tokenId);
+        UserInfo storage info = _users[tokenId];
+        info.user = user;
+        info.expires = expires;
+        emit UpdateUser(tokenId, user, expires);
     }
 
-    function extendAccess(
-        address user,
-        uint256 tokenId
-    )
-        external
-        onlyRole(SPACE_FACTORY)
-        onlyTokenWithinExtensionPeriod(user, tokenId)
-    {
-        _accesses[user].expirationDate += ACCESS_PERIOD;
-        emit ExtendAccess(user, tokenId, _accesses[user].expirationDate);
-    }
-
-    /// @notice Untitled spaceship is burned to create an ultimate spaceship
-    function burn(uint256 tokenId) external onlyRole(SPACE_FACTORY) {
+    /// @notice Basespaceship is burned to create an ultimate spaceship
+    function burn(uint256 tokenId) external {
+        require(
+            _isApprovedOrOwner(msg.sender, tokenId),
+            "ERC721: caller is not token owner or approved"
+        );
+        unchecked {
+            --totalSupply;
+        }
         _burn(tokenId);
     }
 
     /* ============ View Functions ============ */
 
-    function getAccessStatusByUserAddress(
-        address user
-    ) external view returns (Access memory) {
-        return _accesses[user];
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) public view virtual returns (address) {
+        if (uint256(_users[tokenId].expires) >= block.timestamp) {
+            return _users[tokenId].user;
+        } else {
+            return address(0);
+        }
     }
 
-    function getAccessStatusByTokenId(
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(
         uint256 tokenId
-    ) external view returns (Access memory) {
-        return _accesses[_userAddresses[tokenId]];
+    ) public view virtual returns (uint256) {
+        return _users[tokenId].expires;
     }
 
     /* ============ ERC-165 ============ */
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override(ERC721, AccessControl) returns (bool) {
-        return super.supportsInterface(interfaceId);
+    ) public view override(ERC721) returns (bool) {
+        return
+            interfaceId == type(IERC4907).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /* ============ Internal Functions ============ */
@@ -155,5 +104,19 @@ contract BaseSpaceshipNFT is
     // @TODO URI may change in the future
     function _baseURI() internal pure override returns (string memory) {
         return "https://www.spacebar.xyz/base/";
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId,
+        uint256
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId, 1);
+
+        if (from != to && _users[tokenId].user != address(0)) {
+            delete _users[tokenId];
+            emit UpdateUser(tokenId, address(0), 0);
+        }
     }
 }

--- a/contracts/SpaceshipNFT.sol
+++ b/contracts/SpaceshipNFT.sol
@@ -126,7 +126,9 @@ contract SpaceshipNFT is ERC721, AccessControl, IERC4906, ISpaceshipNFT {
     function supportsInterface(
         bytes4 interfaceId
     ) public view override(ERC721, AccessControl, IERC165) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return
+            interfaceId == bytes4(0x49064906) || //IERC4906
+            super.supportsInterface(interfaceId);
     }
 
     // @TODO URI may change in the future

--- a/contracts/interfaces/IBaseSpaceshipNFT.sol
+++ b/contracts/interfaces/IBaseSpaceshipNFT.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
+import "./IERC4907.sol";
 
-interface IBaseSpaceshipNFT {
-    function grantAccess(address user, uint256 tokenId) external;
-
-    function extendAccess(address user, uint256 tokenId) external;
-
+interface IBaseSpaceshipNFT is IERC4907 {
     function burn(uint256 tokenId) external;
 }

--- a/contracts/interfaces/IERC4907.sol
+++ b/contracts/interfaces/IERC4907.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.0;
+
+interface IERC4907 {
+    // Logged when the user of a token assigns a new user or updates expires
+    /// @notice Emitted when the `user` of an NFT or the `expires` of the `user` is changed
+    /// The zero address for user indicates that there is no user address
+    event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
+
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) external ;
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) external view returns(address);
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) external view returns(uint256);
+}


### PR DESCRIPTION
- By converting the Space factory contract into a Base spaceship token holder, the logic can be implemented more concisely.
- Applied IERC4907 for future compatibility


